### PR TITLE
Vertical tabs and things

### DIFF
--- a/appveyor-dark.css
+++ b/appveyor-dark.css
@@ -279,11 +279,12 @@
 
   .vertical-tabs li a:hover {
     background-color: #333 !important;
+    border-left: solid 5px #00b3e0 !important;
     /*color: #00b3e0;*/
   }
 
   .vertical-tabs li.active a {
-    background-color: transparent;
+    background-color: #333 !important;
     color: #00b3e0 !important;
   }
 


### PR DESCRIPTION
### Here I submit

* match hover border color
* active bg color equal to hover

The vertical-tab hover color looks as if it belongs now style wise.
Also the active/selected vertical-tab has the same background as with hover.
There is no good reason to keep line 283 commented out... :wink: 

My justification for these changes is looking at the the unstyled version, it feels like this is the natural evolution, though an argument could be made that the border color could have been a light grey color instead of blue while hover, having tried that myself, it looks off in the dark style, this way looks better.

##### Im open to making the 
```css
  vertical-tabs li.active a {
    background-color: transparent !important;
  }
```
instead... :) just say the word and Ill remove it.

![vt](https://user-images.githubusercontent.com/31389848/39327932-7c0c290c-4991-11e8-8cb9-5b78a63d73a2.gif)

Finally I haven't bumped version here (feel free to add that), I have some other button fixes Im working on. I'de like to fine tune before its ready to submit.
